### PR TITLE
fix: resolve build issues from broken links

### DIFF
--- a/.github/workflows/test-on-pr.yml
+++ b/.github/workflows/test-on-pr.yml
@@ -1,0 +1,23 @@
+name: Test Build is Successful
+
+on:
+  pull_request:
+
+jobs:
+  test-build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Test build
+        run: npm run build

--- a/docs/03-guides/01-repositories/04-keycloak.md
+++ b/docs/03-guides/01-repositories/04-keycloak.md
@@ -22,7 +22,7 @@ The `si-auth-service` repository uses Keycloak for identity management and Postg
 
 ### Prerequisites
 
-- [Docker](/docs//02-tools-and-technologies//03-docker/01-the-basics.md)
+- [Docker](/docs/02-tools-and-technologies/03-docker/01-the-basics.md)
 
 ### Build & Run
 

--- a/docs/03-guides/01-repositories/04-keycloak.md
+++ b/docs/03-guides/01-repositories/04-keycloak.md
@@ -22,7 +22,7 @@ The `si-auth-service` repository uses Keycloak for identity management and Postg
 
 ### Prerequisites
 
-- [Docker](../../02-tools/03-docker/01-the-basics.md)
+- [Docker](/docs//02-tools-and-technologies//03-docker/01-the-basics.md)
 
 ### Build & Run
 

--- a/docs/03-guides/02-cloud-environment/01-aws-cli.md
+++ b/docs/03-guides/02-cloud-environment/01-aws-cli.md
@@ -6,6 +6,6 @@ sidebar_position: 1
 
 ## Prereq
 ---
-- See [Install AWS CLI](../../02-tools/01-aws/01-the-basics.md#install-aws-cli) for instructions on installing and configuring the AWS CLI.
-- See [Setting up Pulumi](../../03-guides/01-setup-local-environment/05-pulumi.md) to setup Pulumi, and get the details of the cloud environment.
+- See [Install AWS CLI](/docs/05-archive/01-aws/01-the-basics.md#install-aws-cli) for instructions on installing and configuring the AWS CLI.
+- See [Setting up Pulumi](../../03-guides/01-repositories/05-pulumi.md) to setup Pulumi, and get the details of the cloud environment.
 - Ensure you have created an account via AWS IAM within the Pulumi Project, with enough privlidgaes for the task at hand.

--- a/docs/03-guides/02-cloud-environment/02-pulumi.md
+++ b/docs/03-guides/02-cloud-environment/02-pulumi.md
@@ -5,6 +5,6 @@ sidebar_position: 1
 # Pulumi (TypeScript)
 ## Prereq
 ---
-- See [Install AWS CLI](/docs/05-archive01-aws/01-the-basics.md#install-aws-cli) for instructions on installing and configuring the AWS CLI.
-- See [Setting up Pulumi](../../03-guides/01-repositores/05-pulumi.md) to setup Pulumi, and get the details of the cloud environment.
+- See [Install AWS CLI](/docs/05-archive/01-aws/01-the-basics.md#install-aws-cli) for instructions on installing and configuring the AWS CLI.
+- See [Setting up Pulumi](/docs/03-guides/01-repositories/05-pulumi.md) to setup Pulumi, and get the details of the cloud environment.
 - Ensure you have created an account via AWS IAM within the Pulumi Project, with enough privlidgaes for the task at hand.

--- a/docs/03-guides/02-cloud-environment/02-pulumi.md
+++ b/docs/03-guides/02-cloud-environment/02-pulumi.md
@@ -5,6 +5,6 @@ sidebar_position: 1
 # Pulumi (TypeScript)
 ## Prereq
 ---
-- See [Install AWS CLI](/docs//05-archive//01-aws//01-the-basics.md#install-aws-cli) for instructions on installing and configuring the AWS CLI.
+- See [Install AWS CLI](/docs/05-archive01-aws/01-the-basics.md#install-aws-cli) for instructions on installing and configuring the AWS CLI.
 - See [Setting up Pulumi](../../03-guides/01-repositores/05-pulumi.md) to setup Pulumi, and get the details of the cloud environment.
 - Ensure you have created an account via AWS IAM within the Pulumi Project, with enough privlidgaes for the task at hand.

--- a/docs/03-guides/02-cloud-environment/02-pulumi.md
+++ b/docs/03-guides/02-cloud-environment/02-pulumi.md
@@ -5,6 +5,6 @@ sidebar_position: 1
 # Pulumi (TypeScript)
 ## Prereq
 ---
-- See [Install AWS CLI](../../02-tools/01-aws/01-the-basics.md#install-aws-cli) for instructions on installing and configuring the AWS CLI.
-- See [Setting up Pulumi](../../03-guides/01-setup-local-environment/05-pulumi.md) to setup Pulumi, and get the details of the cloud environment.
+- See [Install AWS CLI](/docs//05-archive//01-aws//01-the-basics.md#install-aws-cli) for instructions on installing and configuring the AWS CLI.
+- See [Setting up Pulumi](../../03-guides/01-repositores/05-pulumi.md) to setup Pulumi, and get the details of the cloud environment.
 - Ensure you have created an account via AWS IAM within the Pulumi Project, with enough privlidgaes for the task at hand.

--- a/docs/05-archive/01-aws/01-the-basics.md
+++ b/docs/05-archive/01-aws/01-the-basics.md
@@ -7,7 +7,7 @@ description: How to set up the AWS CLI.
 
 ## Prereq
 ---
-- See [Setting up Pulumi](../../03-guides/01-setup-local-environment/05-pulumi.md) to setup Pulumi, and get the details of the cloud environment.
+- See [Setting up Pulumi](../../03-guides/01-repositories/05-pulumi.md) to setup Pulumi, and get the details of the cloud environment.
 - Ensure you have created an account via AWS IAM within the Pulumi Project
 
 ## Install AWS CLI

--- a/docs/05-archive/03-helm/99-kubernetes-temp.md
+++ b/docs/05-archive/03-helm/99-kubernetes-temp.md
@@ -5,7 +5,7 @@ description: Temporary file with notes taken while learning Helm.
 
 # Kubernetes Temp
 
-> This document assumes an understanding of [Docker](../03-docker/01-the-basics.md). Please start there first if you are new to containerization.
+> This document assumes an understanding of [Docker](/docs/02-tools-and-technologies/03-docker/01-the-basics.md). Please start there first if you are new to containerization.
 
 ---
 


### PR DESCRIPTION
We forgot to correct any intra-document links that were broken when the names / locations of folders were updated in PR #12. This PR corrects each of the broken links flagged in the failed build action.

Additionally, a simple workflow has been added that tests the build on any PR to ensure that it is successful. This should allow us to catch these issues before merging to main.